### PR TITLE
Possibility to use a property for the heigth attriubute

### DIFF
--- a/addon/components/summer-note.js
+++ b/addon/components/summer-note.js
@@ -69,8 +69,11 @@ var SummerNoteComponent = Ember.Component.extend({
   doUpdate: function() {
     var content = this.$('.note-editable').html();
     this.set('content', content);
-  }
-
+  },
+  
+  setHeight: function() {
+    this.$().find('.note-editable').css('height', this.get('height')); //use css height, as jQuery heigth/outerHeight does add the padding+margin
+  }.observes('height')
 });
 
 export default SummerNoteComponent;


### PR DESCRIPTION
Added a observer to the height attribute., so the height property can be dynamic as well. 

E.G.:
```javascript
import Ember from 'ember';

export default Ember.ObjectController.extend({
  contentHeight: 200,

  actions: {
    changeHeight(someObject) {
      var height = someObject.doSomeCalculationToGetHeight();
       this.set('contentHeight', heigth)
    }
  }
});
```

`{{summer-note height=contentHeight btnSize=bs-sm content=postContent focus=false header="Example"}}`