### PR TITLE
Added functionality to make read-only by setting "disabled" variable on the component

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ ember g ember-cli-summernote
 ## Basic Usage
 
 ### Handlebar Template
-```
+```javascript
 import Ember from 'ember';
 
 export default Ember.ObjectController.extend({
@@ -33,9 +33,10 @@ export default Ember.ObjectController.extend({
     }
   }
 });
+```
 
+```handlebars
 {{summer-note height=contentHeight btnSize=bs-sm content=postContent focus=false header="Example" disabled=editingDisabled}}
-
 ```
 
 ### Brocfile.js ###

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ import Ember from 'ember';
 export default Ember.ObjectController.extend({
   contentHeight: 200,
   postContent: "Some intial contents go here. Lorem Ipsum is simply dummy text of the printing.",
+  editingDisabled: false,
   
   actions: {
     changeHeight(someObject) {
@@ -33,7 +34,7 @@ export default Ember.ObjectController.extend({
   }
 });
 
-{{summer-note height=contentHeight btnSize=bs-sm content=postContent focus=false header="Example"}}
+{{summer-note height=contentHeight btnSize=bs-sm content=postContent focus=false header="Example" disabled=editingDisabled}}
 
 ```
 

--- a/addon/components/summer-note.js
+++ b/addon/components/summer-note.js
@@ -9,6 +9,7 @@ var SummerNoteComponent = Ember.Component.extend({
   height: 120,
   focus: false,
   airMode: false,
+  disabled: false,
 
   willDestroyElement: function() {
     this.$('textarea').destroy();
@@ -53,6 +54,8 @@ var SummerNoteComponent = Ember.Component.extend({
       // ]
     });
 
+    this.$().find('.note-editable').attr('contenteditable', !this.get('disabled'));
+
     var _content = this.get('content');
     this.$('textarea').code(_content);
     this.$('.btn').addClass(_btnSize);
@@ -73,7 +76,11 @@ var SummerNoteComponent = Ember.Component.extend({
   
   setHeight: function() {
     this.$().find('.note-editable').css('height', this.get('height')); //use css height, as jQuery heigth/outerHeight does add the padding+margin
-  }.observes('height')
+  }.observes('height'),
+
+  setContentEditable: function() {
+    this.$().find('.note-editable').attr('contenteditable', !this.get('disabled'));
+  }.observes('disabled')
 });
 
 export default SummerNoteComponent;

--- a/tests/dummy/app/controllers/examples.js
+++ b/tests/dummy/app/controllers/examples.js
@@ -4,6 +4,8 @@ var ExamplesController = Ember.Controller.extend({
 
   postContent: 'Hello, world!',
 
+  editingDisabled: false,
+
   actions: {
     
   }

--- a/tests/dummy/app/templates/examples.hbs
+++ b/tests/dummy/app/templates/examples.hbs
@@ -2,11 +2,13 @@
     <pre>
 
      Use the following code to put a wysiwyg editor.
-    &#123;&#123;summer-note content=postContent header="Example"&#125;&#125;
+    &#123;&#123;summer-note content=postContent header="Example" disabled=myControlVariable&#125;&#125;
     </pre>
     <div class='container'>
       <h3>Example </h3>
-      {{summer-note height=200 btnSize=bs-sm content=postContent focus=false header="Example"}}
+      {{summer-note height=200 btnSize=bs-sm content=postContent focus=false header="Example" disabled=editingDisabled}}
+
+      <p>Disable editing {{input type="checkbox" checked=editingDisabled}}</p>
     </div>
     <div class="container"> 
       <div class='wysiwyg-preview'>


### PR DESCRIPTION
I have added functionality to make the input read-only, by setting the disabled variable. The disabling is accomplished by modifying ```contenteditable``` on the Summernote editor div.

Obviously, ```disabled=false``` by default, so any existing code will work fine without any changes.

To try out the disable functionality, run the example. The checkbox under the editor controls read-only mode. 

---

#### Example use case:
User is drafting a post and editing isn't allowed after it has been published. You can bind the post editor using the following: 

```handlebars
{{summer-note height=200 btnSize=bs-sm content=model.postText focus=false header="Example" disabled=model.isPublished}}
```