### PR TITLE
Enabled content update when in Html View

### DIFF
--- a/addon/components/summer-note.js
+++ b/addon/components/summer-note.js
@@ -70,7 +70,7 @@ var SummerNoteComponent = Ember.Component.extend({
   },
 
   doUpdate: function() {
-    var content = this.$('.note-editable').html();
+    var content = this.$('textarea').code();
     this.set('content', content);
   },
   


### PR DESCRIPTION
Content property was not being updated on changes when editing the summernote content in HTML view, this change captures those changes and means you do not need to switch back from code view prior to saving a form.