### PR TITLE
Removed debug logging upon content change event

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,11 @@ matrix:
 
 before_install:
   - npm config set spin false
-  - npm install -g bower
-  - bower --version
   - npm install -g phantomjs-prebuilt
   - phantomjs --version
 
-
 install:
   - npm install
-  - bower install
-
 
 script:
   # Usually, it's ok to finish the test scenario without reverting

--- a/addon/components/summer-note.js
+++ b/addon/components/summer-note.js
@@ -4,7 +4,6 @@ import layout from '../templates/components/summer-note';
 const {
   get,
   assert,
-  Logger,
   getOwner,
   isEqual,
   isEmpty,
@@ -25,15 +24,12 @@ export default Component.extend({
   callbacks: {},
 
   config: Ember.computed(function() {
-    //let applicationConfig = this.container.lookupFactory('config:environment');
     let applicationConfig = getOwner(this).resolveRegistration('config:environment');
-    // Logger.debug(`applicationConfig.ember-cli-summernote: ${JSON.stringify(applicationConfig)}`);
 
     return applicationConfig;
   }),
 
   onChange(text) {
-    Logger.debug(`onChange callback. text: ${text}`);
     let _onContentChange = this.get('onContentChange');
     if (!isEmpty(_onContentChange)) {
       _onContentChange(text);
@@ -42,7 +38,6 @@ export default Component.extend({
 
   willDestroyElement: function() {
     this.$('.summernote').summernote('destroy');
-    // Logger.debug('summernote('destroy')');
   },
 
   didInsertElement: function() {


### PR DESCRIPTION
Hello,

I honestly do not think logging upon content change event in the addon itself is useful. It's a real pain for debugging, as these logs can get extra lengthy for a WYSIWYG component, and one can easily log these changes themselves in their controller or container component.

Cheers!